### PR TITLE
Update python_info aspect to accommodate Python targets that only have rules_python providers

### DIFF
--- a/server/aspects/rules/python/python_info.bzl.template
+++ b/server/aspects/rules/python/python_info.bzl.template
@@ -1,12 +1,15 @@
-#if( $pythonEnabled == "true" && $bazel8OrAbove == "true" )
+#if( $pythonEnabled == "true" )
+#if( $bazel8OrAbove == "true")
 load("@rules_python//python:defs.bzl", "PyInfo", "PyRuntimeInfo")
+#end
+load("@rules_python//python:defs.bzl", PyInfoRulesPython = "PyInfo", PyRuntimeInfoRulesPython = "PyRuntimeInfo")
 #end
 
 load("//aspects:utils/utils.bzl", "create_struct", "file_location", "to_file_location")
 
 def py_info_in_target(target):
     #if( $pythonEnabled == "true" )
-    return PyInfo in target
+    return PyInfo in target or PyInfoRulesPython in target
 
     #else
     return False
@@ -14,7 +17,7 @@ def py_info_in_target(target):
 
 def py_runtime_info_in_target(target):
     #if( $pythonEnabled == "true" )
-    return PyRuntimeInfo in target
+    return PyRuntimeInfo in target or PyRuntimeInfoRulesPython in target
 
     #else
     return False
@@ -24,6 +27,8 @@ def get_py_info(target):
     #if( $pythonEnabled == "true" )
     if PyInfo in target:
         return target[PyInfo]
+    elif PyInfoRulesPython in target:
+        return target[PyInfoRulesPython]
     else:
         return None
 
@@ -35,6 +40,8 @@ def get_py_runtime_info(target):
     #if( $pythonEnabled == "true" )
     if PyRuntimeInfo in target:
         return target[PyRuntimeInfo]
+    elif PyRuntimeInfoRulesPython in target:
+        return target[PyRuntimeInfoRulesPython]
     else:
         return None
 


### PR DESCRIPTION
As the Python rules are gradually phasing out use of the builtin PyInfo provider in favor of the one from rules_python, there could be cases where a repository is on a Bazel version lower than 8, but the built in PyInfo is still missing from a given target.

In our repo's case, we are in the process of migrating to rules_py, which uses the rules_python providers and not the built in ones.

This change adjusts the aspect to always include the rules_python providers, under an alias, regardless of Bazel version, and to use them if there are no built in providers for a given target.  In addition, for Bazel 8 compatibility, this keeps the existing load under the original names.